### PR TITLE
Add site level permission for moderator approval

### DIFF
--- a/bbb_view.php
+++ b/bbb_view.php
@@ -369,7 +369,11 @@ function bigbluebuttonbn_bbb_view_create_meeting_data(&$bbbsession) {
     if ($bbbsession['lockonjoinconfigurable']) {
         $data['lockSettingsLockOnJoinConfigurable'] = 'true';
     }
-    if ($bbbsession['bigbluebuttonbn']->moderatorapproval) {
+    // Check global mod settings first, otherwise check activity instance settings
+    if (
+        \mod_bigbluebuttonbn\locallib\config::get('participant_guest_requires_moderator_approval')
+        || $bbbsession['bigbluebuttonbn']->moderatorapproval
+    ) {
         $data['guestPolicy'] = 'ASK_MODERATOR';
     }
     return $data;

--- a/classes/locallib/config.php
+++ b/classes/locallib/config.php
@@ -146,7 +146,7 @@ class config {
     }
 
     /**
-     * Validates if recording settings are enabled.
+     * Validates if guestlink settings are enabled.
      *
      * @return boolean
      */
@@ -266,6 +266,8 @@ class config {
                'lockonjoinconfigurable_editable' => self::get('lockonjoinconfigurable_editable'),
                'lockonjoinconfigurable_default' => self::get('lockonjoinconfigurable_default'),
                'welcome_default' => self::get('welcome_default'),
+               'participant_guestlink' => self::get('participant_guestlink'),
+               'participant_guest_requires_moderator_approval' => self::get('participant_guest_requires_moderator_approval'),
           );
     }
 }

--- a/classes/locallib/config.php
+++ b/classes/locallib/config.php
@@ -128,6 +128,8 @@ class config {
             'accessmodal_editable' => true,
             'accessmodal_default' => '',
             'welcome_default' => '',
+            'participant_guestlink' => '',
+            'participant_guest_requires_moderator_approval' => false,
         );
     }
 

--- a/lang/en/bigbluebuttonbn.php
+++ b/lang/en/bigbluebuttonbn.php
@@ -192,6 +192,8 @@ $string['config_participant'] = 'Participant configuration';
 $string['config_participant_description'] = 'These settings define the role by default for participants in a conference.';
 $string['config_participant_guestlink'] = 'Allow guest access links';
 $string['config_participant_guestlink_description'] = 'Allow moderator to create a guest access link for external participants.';
+$string['config_participant_guest_requires_moderator_approval'] = 'Moderator must approve guests';
+$string['config_participant_guest_requires_moderator_approval_description'] = 'Moderators must always approve guests. Enabling this will lock and hide the option from the activity setting';
 
 $string['config_participant_moderator_default'] = 'Moderator by default';
 $string['config_participant_moderator_default_description'] = 'This rule is used by default when a new room is added.';

--- a/locallib.php
+++ b/locallib.php
@@ -3020,6 +3020,11 @@ function bigbluebuttonbn_settings_participants(&$renderer) {
             'participant_guestlink',
             $renderer->render_group_element_checkbox('participant_guestlink', 0)
         );
+        // Option for locking (and hiding) the settings for moderator approval on a global level
+        $renderer->render_group_element(
+            'participant_guest_requires_moderator_approval',
+            $renderer->render_group_element_checkbox('participant_guest_requires_moderator_approval', 0)
+        );
         // UI for 'participants' feature.
         $roles = bigbluebuttonbn_get_roles(null, false);
         $owner = array('0' => get_string('mod_form_field_participant_list_type_owner', 'bigbluebuttonbn'));

--- a/mod_form.php
+++ b/mod_form.php
@@ -387,12 +387,16 @@ class mod_bigbluebuttonbn_mod_form extends moodleform_mod {
      * @return void
      */
     private function bigbluebuttonbn_mform_add_block_guestlink(&$mform, $cfg) {
-        if (\mod_bigbluebuttonbn\locallib\config::get('participant_guestlink')) {
-                $mform->addElement('header', 'guestlink', get_string('mod_form_block_guestlink', 'bigbluebuttonbn'));
-                $mform->addElement('advcheckbox', 'guestlinkenabled',
-                        get_string('mod_form_field_guestlinkenabled', 'bigbluebuttonbn'), ' ');
+        if ($cfg['participant_guestlink']) {
+            $mform->addElement('header', 'guestlink', get_string('mod_form_block_guestlink', 'bigbluebuttonbn'));
+            $mform->addElement('advcheckbox', 'guestlinkenabled',
+                    get_string('mod_form_field_guestlinkenabled', 'bigbluebuttonbn'), ' ');
+
+            // If site-level moderatorapproval is required, do not include this element (as it should be automatically applied)
+            if (!$cfg['participant_guest_requires_moderator_approval']) {
                 $mform->addElement('advcheckbox', 'moderatorapproval',
                         get_string('mod_form_field_moderatorapproval', 'bigbluebuttonbn'), ' ');
+            }
         }
     }
     /**

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version = 2020050504;
+$plugin->version = 2020050505;
 $plugin->requires = 2016120500;
 $plugin->cron = 0;
 $plugin->component = 'mod_bigbluebuttonbn';


### PR DESCRIPTION
Added checkbox option in site-level plugin settings, to add the guestPolicy of ASK_MODERATOR to the metadata when a session is created. 

This option will also hide the option to enable/disable the moderatorapproval flag, and will always be used instead of the instance setting when it is enabled.