### PR TITLE
Add access policy to the guestlink landing page

### DIFF
--- a/guestlink.php
+++ b/guestlink.php
@@ -63,7 +63,33 @@ if (!$valid) {
     ];
 
     echo $OUTPUT->header();
+
+    // Setup access policy modal window
+    // If global editing is disabled, it is always the global version.
+    // Note: Duplicate block @ mod/bigbluebuttonbn/viewlib.php:258
+    if ((int) $CFG->bigbluebuttonbn_accessmodal_editable) {
+        $policytext = format_text($bbbsession['bigbluebuttonbn']->accesspolicy ?? '');
+        // If empty here, try the default policy.
+        if (empty(strip_tags($policytext))) {
+            $policytext = format_text($CFG->bigbluebuttonbn_accessmodal_default ?? '');
+        }
+    } else {
+        $policytext = format_text($CFG->bigbluebuttonbn_accessmodal_default ?? '');
+    }
+
+    // Check if there is any content with HTML stripped.
+    if (!empty(strip_tags($policytext))) {
+        echo $OUTPUT->render_from_template('mod_bigbluebuttonbn/accesspolicy', [
+            'body' => $policytext,
+            'forward' => null,
+            'hash' => md5($policytext),
+            'alert' => get_string('accesspolicyalert', 'mod_bigbluebuttonbn')
+        ]);
+        // Add the JS var to setup the modal from JS.
+        $context['accesspolicy'] = true;
+    }
     echo $OUTPUT->render_from_template('mod_bigbluebuttonbn/guestaccess_view', $context);
+
     echo $OUTPUT->footer();
 } else {
     list($course, $cm) = get_course_and_cm_from_instance($bigbluebuttonbn, 'bigbluebuttonbn');

--- a/templates/accesspolicy.mustache
+++ b/templates/accesspolicy.mustache
@@ -19,15 +19,30 @@
 require(['jquery', 'core/sessionstorage'], function($, Storage) {
     var hash = $('#policymodal').data('hash');
 
+    let handlePolicyAcceptedCallback = () => {
+
+        // If a destination/forward is set, redirect to the intended URL
+        let destination = "{{{forward}}}";
+        if (destination) {
+            window.location.href = destination;
+        }
+        // Otherwise execute the callback set if one exists on the policy modal
+        else {
+            $('#policymodal').data('callback')?.()
+        }
+    }
+
     $('#policymodalaccept').on('click', (e) => {
         Storage.set('mod_bigbluebutton_policyaccepted' + hash, 'true');
+        e.preventDefault();
+        handlePolicyAcceptedCallback();
     });
 
     // If the storage key for accepting the policy is set,
     $('#policymodal').on('show.bs.modal', (e) => {
         if (Storage.get('mod_bigbluebutton_policyaccepted' + hash) === 'true') {
             e.preventDefault();
-            window.location.href = "{{{forward}}}";
+            handlePolicyAcceptedCallback();
         }
     });
 

--- a/templates/guestaccess_view.mustache
+++ b/templates/guestaccess_view.mustache
@@ -2,10 +2,9 @@
 <div class="row shiftrow">
     <div class="col-lg-3 col-md-3 col-sm-3"> </div>
     <div class="col-lg-6 col-md-6 col-sm-6">
-            <h4 class="text-left">{{# str }} guestlink_form_join_welcome,bigbluebuttonbn {{/ str }} </h4>
+        <h4 class="text-left">{{# str }} guestlink_form_join_welcome,bigbluebuttonbn {{/ str }} </h4>
     </div>
     <div class="col-lg-3 col-md-3 col-sm-3"> </div>
-
 </div>
 <div class="row">
     <div class="col-lg-3 col-md-3 col-sm-3"> </div>
@@ -35,16 +34,17 @@
     <input type="hidden" name="gid" value="{{gid}}"/>
     <div class="col-lg-3 col-md-3 col-sm-3"> </div>
     <div class="col-lg-2 col-md-2 col-sm-2">
-    {{#guestnameerrormessage}}
-        <div class="warning">
-            {{# str }} guestlink_form_join_no_username,bigbluebuttonbn {{/ str }}
-        </div>
-    {{/guestnameerrormessage}}
-    </div>    <div class="col-lg-2 col-md-2 col-sm-2">
-            <input type="text" class="form-control " name="guestname" id="id_guestname" value="{{guestname}}" size="" placeholder="{{# str }} guestlink_form_guestname_info,bigbluebuttonbn {{/ str }}" >
+        {{#guestnameerrormessage}}
+            <div class="warning">
+                {{# str }} guestlink_form_join_no_username,bigbluebuttonbn {{/ str }}
+            </div>
+        {{/guestnameerrormessage}}
     </div>
-    <div class="col-lg-5 col-md-5 col-sm-5"  style="padding-left:0px;">
-            <input type="submit" class="btn btn-primary inputbutton" name="joinbutton" id="id_joinbutton" value="{{# str }} guestlink_form_join_button,bigbluebuttonbn {{/ str }}">
+    <div class="col-lg-2 col-md-2 col-sm-2">
+        <input type="text" class="form-control " name="guestname" id="id_guestname" value="{{guestname}}" size="" placeholder="{{# str }} guestlink_form_guestname_info,bigbluebuttonbn {{/ str }}" >
+    </div>
+    <div class="col-lg-5 col-md-5 col-sm-5" style="padding-left:0px;">
+        <input type="submit" class="btn btn-primary inputbutton" name="joinbutton" id="id_joinbutton" value="{{# str }} guestlink_form_join_button,bigbluebuttonbn {{/ str }}">
     </div>
 </div>
 </form>
@@ -63,7 +63,18 @@ var validateForm = function() {
         return false;
     }
 };
-
 document.getElementById("id_joinbutton").onclick = validateForm;
+
+{{#accesspolicy}}
+let showAccessPolicy = () => {
+    $("#policymodal").data("callback", function() {
+        document.forms["guestlinkform"].submit()
+    });
+    $("#policymodal").modal("show");
+    return false
+}
+document.forms["guestlinkform"].onsubmit = showAccessPolicy
+{{/accesspolicy}}
+
 {{/js}}
 {{/element.frozen}}

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version = 2020050505;
+$plugin->version = 2020050506;
 $plugin->requires = 2016120500;
 $plugin->cron = 0;
 $plugin->component = 'mod_bigbluebuttonbn';


### PR DESCRIPTION
This adds additional behaviour to not interfere with existing functionality, and will trigger a formsubmission as part of the callback when the user has accepted the policy before.