### PR TITLE
Add additional metrics for recordings

### DIFF
--- a/analytics-recordings.php
+++ b/analytics-recordings.php
@@ -1,0 +1,196 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Views analytics/metrics on all the recordings logged from BBB for a specific
+ * BBB instance, or for all BBB instances ever created
+ *
+ * @package    mod_bigbluebuttonbn
+ * @copyright  Kevin Pham <kevinpham@catalyst-au.net>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+use mod_bigbluebuttonbn\plugin;
+
+require(__DIR__.'/../../config.php');
+require_once($CFG->libdir.'/adminlib.php');
+require_once(__DIR__.'/locallib.php');
+require_once(__DIR__.'/viewlib.php');
+require_once($CFG->libdir.'/tablelib.php');
+require_once($CFG->dirroot.'/mod/bigbluebuttonbn/lib.php');
+
+$group = optional_param('group', 0, PARAM_INT);
+$download = optional_param('download', '', PARAM_ALPHA);
+$bn = optional_param('bn', 0, PARAM_INT);
+
+// Check and scope the report (all site vs single BBB instance).
+if (!empty($bn)) {
+    // Scoping checks for the BBB instance.
+    $viewinstance = bigbluebuttonbn_view_validator(null, $bn); // In locallib.
+    if (!$viewinstance) {
+        throw new invalid_parameter_exception(get_string('view_error_url_missing_parameters', 'bigbluebuttonbn'));
+    }
+    $cm = $viewinstance['cm'];
+    $course = $viewinstance['course'];
+    $bigbluebuttonbn = $viewinstance['bigbluebuttonbn'];
+    require_login($course, true, $cm);
+    $title = $bigbluebuttonbn->name;
+    $heading = $course->fullname;
+
+} else {
+    // Checks for the site admin report.
+    require_login();
+    require_capability('mod/bigbluebuttonbn:recording_analytics', context_system::instance());
+    $title = get_string('view_analytics_heading_recordings', 'bigbluebuttonbn');
+    $heading = get_string('bigbluebuttonbn', 'bigbluebuttonbn');
+    admin_externalpage_setup('bigbluebuttonbnrecordingsanalyticsreport', '', null, '', array('pagelayout' => 'report'));
+}
+
+// Print the page header.
+$pageurl = new moodle_url('/mod/bigbluebuttonbn/analytics-recordings.php', ['bn' => $bn]);
+$PAGE->set_url($pageurl);
+$PAGE->set_title($title);
+$PAGE->set_cacheable(false);
+$PAGE->set_heading($heading);
+
+$table = new \mod_bigbluebuttonbn\analytics\analytics_for_recordings_table('bigbluebuttonbn_recordings_metrics_table', $PAGE->url);
+$table->is_downloading($download);
+
+if (!$download) {
+    // Only print headers if not asked to download data.
+    $PAGE->set_title($title);
+    $PAGE->set_cacheable(false);
+    $PAGE->set_heading($heading);
+    $PAGE->navbar->add(get_string('view_section_title_analytics', 'bigbluebuttonbn'), $pageurl);
+    echo $OUTPUT->header();
+}
+
+// Analytics Report Query.
+$wheresql = "meta IS NOT NULL
+             AND log = :log
+             AND userid IS NOT NULL";
+$params = ['log' => BIGBLUEBUTTONBN_LOG_EVENT_CREATE];
+if (!empty($bn) && !empty($bigbluebuttonbn->id)) {
+    $wheresql .= " AND bigbluebuttonbnid = :bigbluebuttonbnid";
+    $params['bigbluebuttonbnid'] = $bigbluebuttonbn->id;
+}
+$table->set_sql('id, meta, userid', "{bigbluebuttonbn_logs}", $wheresql, $params);
+$table->define_baseurl($pageurl);
+
+// Add cloned table modifying the query for past week instead.
+$pastweektable = clone $table;
+$wheresqlwithweekconstraint = $wheresql;
+$wheresql .= " AND timecreated > :timecreated";
+$params['timecreated'] = time() - WEEKSECS;
+$pastweektable->set_sql('id, meta, userid', "{bigbluebuttonbn_logs}", $wheresql, $params);
+$pastweektable->setup();
+$pastweektable->query_db(0); // No limit, fetch all rows.
+$pastweektable->pageable(false);
+$pastweektable->close_recordset();
+$pastweekmeetingcreateevents = $pastweektable->rawdata;
+
+$output = "";
+
+// Prepare attendee data for Attention Box.
+$table->setup();
+$table->query_db(0); // No limit, fetch all rows.
+$table->pageable(false);
+$table->close_recordset();
+$meetingcreateevents = $table->rawdata;
+
+if (isset($meetingsummary->meta)) {
+    $meetingsummary->meta = json_decode($meetingsummary->meta);
+}
+
+if (!$download && !empty($meetingcreateevents)) {
+    $tables = "";
+    $output .= $OUTPUT->heading(get_string('view_analytics_heading_recordings', 'bigbluebuttonbn'), 3);
+
+    // Function to help render the table given the data ($events) and a table name.
+    $createoverviewtable = function($tablename, $events) {
+        // Helper function to return a reducer that will sum an array of objects
+        // given a key. This will default to zero for the value if the value does
+        // not exist in the object.
+        $sumkeyfunc = function($key) use($events) {
+            return array_reduce($events, function($acc, $row) use ($key) {
+                $data = json_decode($row->meta);
+                return $acc + ($data->{$key} ?? 0);
+            }, 0);
+        };
+
+        $processingdurationtotalinseconds = $sumkeyfunc('processingduration') / 1000;
+        $filesizetotal = $sumkeyfunc('filesize');
+        $overviewtable = new html_table();
+        $overviewtable->caption = $tablename;
+        $overviewtable->attributes['class'] = 'w-auto admintable generaltable mr-4 table-bordered';
+        $htmlparams = ['class' => 'text-center'];
+        $data = [
+            [get_string('view_analytics_total_recordings', 'bigbluebuttonbn'), count($events)],
+            [get_string('view_analytics_total_storage_used', 'bigbluebuttonbn'), display_size($filesizetotal)],
+            [
+                get_string('view_analytics_total_playback_duration', 'bigbluebuttonbn'),
+                userdate($sumkeyfunc('playbackduration') / 1000, get_string('strftimetime24seconds', 'bigbluebuttonbn'), 'UTC')
+            ],
+            [
+                get_string('view_analytics_total_processing_time', 'bigbluebuttonbn'),
+                userdate($processingdurationtotalinseconds, get_string('strftimetime24seconds', 'bigbluebuttonbn'), 'UTC')
+            ],
+            [
+                get_string('view_analytics_average_queue_time', 'bigbluebuttonbn'),
+                userdate($sumkeyfunc('queuetime') / 1000, get_string('strftimetime24seconds', 'bigbluebuttonbn'), 'UTC')
+            ],
+            [
+                get_string('view_analytics_average_processing_time', 'bigbluebuttonbn'),
+                userdate(
+                    $processingdurationtotalinseconds / count($events),
+                    get_string('strftimetime24seconds', 'bigbluebuttonbn'),
+                    'UTC'
+                )
+            ],
+            [
+                get_string('view_analytics_processing_speed', 'bigbluebuttonbn'),
+                display_size($processingdurationtotalinseconds ? ($filesizetotal / $processingdurationtotalinseconds) : 0).' / sec'
+            ],
+        ];
+        $overviewtable->data = $data;
+        $overviewtablehtml = html_writer::table($overviewtable);
+        return $overviewtablehtml;
+    };
+
+    // Generate and return the HTML for the Ovewview Section.
+    $tables .= $createoverviewtable(
+        get_string('view_analytics_heading_overview', 'bigbluebuttonbn'),
+        $meetingcreateevents);
+
+    // Generate and return the HTML for the Past Week Section.
+    $tables .= $createoverviewtable(
+        "Past week",
+        $pastweekmeetingcreateevents);
+
+    // Add all tables to the output.
+    $output .= '<div class="d-flex align-items-start">'.$tables.'</div>';
+}
+
+if (!$download) {
+    echo $output;
+}
+
+$table->build_table();
+$table->finish_output();
+
+if (!$download) {
+    echo $OUTPUT->footer();
+}

--- a/classes/analytics/analytics_for_recordings_table.php
+++ b/classes/analytics/analytics_for_recordings_table.php
@@ -1,0 +1,147 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace mod_bigbluebuttonbn\analytics;
+
+/**
+ * Analytics Table
+ *
+ * @package   bigbluebuttonbn
+ * @author    Kevin Pham <kevinpham@catalyst-au.net>
+ * @copyright 2021 onwards Catalyst IT Ltd
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class analytics_for_recordings_table extends \table_sql {
+
+    private $datetimeformat;
+    private $durationformat;
+
+    public function __construct($uniqueid, \moodle_url $url, $perpage = 100) {
+        parent::__construct($uniqueid);
+        $this->datetimeformat = get_string('strftimedatetimetimezone', 'bigbluebuttonbn');
+        $this->durationformat = get_string('strftimetime24seconds', 'bigbluebuttonbn');
+
+        $this->set_attribute('class', 'generaltable generalbox');
+        $cols = [
+            'createtime',
+            'starttime',
+            'endtime',
+            'playbackduration',
+            'queuestarttime',
+            'queueduration',
+            'processingtime',
+            'processingduration',
+            'filesize', // Size in bytes of the recording.
+
+            // TODO: Fancy number #1: Relative processing time speed compared with the median/average
+            // TODO: Fancy number #2: Std deviation / where it sits in terms of other recordings for processing
+            // TODO: Cross link to reccording?
+            // TODO: Cross link to session analytics?
+        ];
+
+        $this->define_columns($cols);
+        $this->define_headers([
+            get_string('view_analytics_createtime', 'bigbluebuttonbn'),
+            get_string('view_analytics_starttime', 'bigbluebuttonbn'),
+            get_string('view_analytics_endtime', 'bigbluebuttonbn'),
+            get_string('view_analytics_playbackduration', 'bigbluebuttonbn'),
+            get_string('view_analytics_queuestarttime', 'bigbluebuttonbn'),
+            get_string('view_analytics_queueduration', 'bigbluebuttonbn'),
+            get_string('view_analytics_processingtime', 'bigbluebuttonbn'),
+            get_string('view_analytics_processingduration', 'bigbluebuttonbn'),
+            get_string('view_analytics_filesize', 'bigbluebuttonbn'),
+        ]);
+        $this->pagesize = $perpage;
+        $systemcontext = \context_system::instance();
+        $this->context = $systemcontext;
+        $this->collapsible(false);
+        $this->sortable(false, 'timecreated', SORT_DESC); // This is due to the data being stored in the meta field as json.
+        $this->pageable(false);
+        $this->is_downloadable(true);
+        $this->define_baseurl($url);
+    }
+
+
+    public function col_createtime($row) {
+        $data = json_decode($row->meta);
+        return userdate($data->createtime / 1000, $this->datetimeformat);
+    }
+
+    public function col_starttime($row) {
+        $data = json_decode($row->meta);
+        return userdate($data->starttime / 1000, $this->datetimeformat);
+    }
+
+    public function col_endtime($row) {
+        $data = json_decode($row->meta);
+        if (isset($data->endtime)) {
+            return userdate($data->endtime / 1000, $this->datetimeformat);
+        }
+        return '-';
+    }
+
+    public function col_playbackduration($row) {
+        $data = json_decode($row->meta);
+        if (!empty($data->playbackduration)) {
+            return userdate($data->playbackduration / 1000, $this->durationformat, 'UTC');
+        }
+        return '-';
+    }
+
+    // Calculated by taking the time it finished processing - deduct the processing time, deduct the queue time.
+    public function col_queuestarttime($row) {
+        $data = json_decode($row->meta);
+        if (empty($data->recordinglastmodified) || empty($data->processingduration) || empty($data->queuetime)) {
+            return '-';
+        }
+        $queuestarttime = $data->recordinglastmodified - $data->processingduration - $data->queuetime;
+        return userdate($queuestarttime / 1000, $this->datetimeformat);
+    }
+
+    public function col_queueduration($row) {
+        $data = json_decode($row->meta);
+        if (!empty($data->queueduration)) {
+            return userdate($data->queueduration / 1000, $this->durationformat, 'UTC');
+        }
+        return '-';
+    }
+
+    public function col_processingtime($row) {
+        $data = json_decode($row->meta);
+        if (empty($data->recordinglastmodified) || empty($data->processingduration)) {
+            return '-';
+        }
+        $processingtime = $data->recordinglastmodified - $data->processingduration;
+        return userdate($processingtime / 1000, $this->datetimeformat);
+    }
+
+    public function col_processingduration($row) {
+        $data = json_decode($row->meta);
+        if (!empty($data->processingduration)) {
+            return userdate($data->processingduration / 1000, $this->durationformat, 'UTC');
+        }
+        return '-';
+    }
+
+    public function col_filesize($row) {
+        $data = json_decode($row->meta);
+        if (isset($data->filesize)) {
+            return display_size($data->filesize);
+        }
+        return '-';
+    }
+
+}

--- a/classes/analytics/analytics_per_session_table.php
+++ b/classes/analytics/analytics_per_session_table.php
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace mod_bigbluebuttonbn\analytics;
+
 /**
  * Analytics Table
  *
@@ -22,9 +24,6 @@
  * @copyright 2021 onwards Catalyst IT Ltd
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
-namespace mod_bigbluebuttonbn\analytics;
-
 class analytics_per_session_table extends \table_sql {
 
     public function __construct($uniqueid, \moodle_url $url, $perpage = 100) {

--- a/classes/task/fetch_recording_metadata_task.php
+++ b/classes/task/fetch_recording_metadata_task.php
@@ -1,0 +1,151 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace mod_bigbluebuttonbn\task;
+
+defined('MOODLE_INTERNAL') || die();
+
+// Time between checking the same record.
+const TIME_BETWEEN_SUBSEQUENT_CHECKS = 20 * MINSECS;
+// After 2 weeks from the meeting start date, if no recording metadata is
+// returned, consider the meeting as recording-free.
+const TIME_BEFORE_FLAGGING_AS_NOT_RECORDED = 2 * WEEKSECS;
+// This is a limit documented in code @  bigbluebuttonbn_get_recordings_array_fetch_page function call.
+const BBB_API_GET_RECORDINGS_RECORDS_PER_REQUEST = 25;
+// Default processing limit for backlog of BBB sessions.
+const DEFAULT_PROCESSING_LIMIT = 100;
+
+/**
+ * A scheduled task to fetch the recordings' metadata and store it for further reporting
+ *
+ * @package    mod_bigbluebuttonbn
+ * @author     Kevin Pham <kevinpham@catalyst-au.net>
+ * @copyright  Catalyst IT, 2021
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class fetch_recording_metadata_task extends \core\task\scheduled_task {
+
+    /**
+     * Get a descriptive name for this task (shown to admins).
+     *
+     * @return string
+     */
+    public function get_name() {
+        return get_string('fetchmetaforrecordings', 'mod_bigbluebuttonbn');
+    }
+
+    /**
+     * Run chat cron.
+     */
+    public function execute() {
+        require_once(__DIR__.'/../../locallib.php');
+        global $CFG, $DB;
+
+        $sql = "SELECT recordid, id, *
+                  FROM {bigbluebuttonbn_logs}
+                 WHERE recordid IS NOT NULL
+                   AND log = :log
+                   AND ".$DB->sql_like('meta', ':recordtrue')."
+                   AND ".$DB->sql_like('meta', ':recordedfalse', false, false, $notlike = true)."
+                   AND (
+                       ".$DB->sql_like('meta', ':recordinglastmodified', false, false, $notlike = true)."
+                       OR ".$DB->sql_like('meta', ':endtime', false, false, $notlike = true).")
+                 LIMIT :limit
+                   ";
+        $meetingswithnorecordingmeta = $DB->get_records_sql($sql, [
+            'log' => BIGBLUEBUTTONBN_LOG_EVENT_CREATE,
+            'recordtrue' => '%"record":"true"%', // Recording is enabled.
+            'recordedfalse' => '%"recorded":false%', // Recording did not happen (set after meeting ended).
+            'recordinglastmodified' => '%recordinglastmodified%',
+            'endtime' => '%endtime%',
+            'limit' => DEFAULT_PROCESSING_LIMIT
+        ]);
+        // Filter out all the meetings that have been recently checked, so we can.
+        $relevantmeetings = [];
+        foreach ($meetingswithnorecordingmeta as $recordid => $meeting) {
+            $meta = json_decode($meeting->meta);
+            // Check the time for lastchecked, and make sure that it has been at least
+            // 20 minutes from the last check for it to check again.
+            if (!isset($meta->lastchecked) || time() > $meta->lastchecked + TIME_BETWEEN_SUBSEQUENT_CHECKS) {
+                $relevantmeetings[$recordid] = $meeting;
+            }
+        }
+
+        // Split the records to process in chunks, such that they will not go over the
+        // 25 record response from BBB's getRecordings call.
+        $chunkedmeetings = array_chunk($relevantmeetings, BBB_API_GET_RECORDINGS_RECORDS_PER_REQUEST, $preservekeys = true);
+
+        foreach ($chunkedmeetings as $relevantmeetings) {
+            // Fetch and update the record's recordinglastmodified timestamp.
+            $recordids = array_keys($relevantmeetings);
+            $metas = bigbluebuttonbn_get_recordings_meta($recordids);
+            // Fetch and set the endtime for the meeting based on the recording info.
+            $recordings = bigbluebuttonbn_get_recordings_array_fetch_page([], $recordids);
+            // Loop through and perform updates as required based on information gathered.
+            foreach ($relevantmeetings as $recordid => $meeting) {
+                $meta = json_decode($meeting->meta);
+                // Ensure it only sets the metadata if it has not already been set or is empty.
+                if (empty($meta->recordinglastmodified) && isset($metas[$recordid]['lastmodified'])) {
+                    $meta->recordinglastmodified = $metas[$recordid]['lastmodified'];
+                }
+                if (empty($meta->filesize) && isset($metas[$recordid]['filesize'])) {
+                    $meta->filesize = $metas[$recordid]['filesize'];
+                }
+                if (empty($meta->playbackduration) && isset($metas[$recordid]['playbackduration'])) {
+                    $meta->playbackduration = $metas[$recordid]['playbackduration'];
+                }
+                if (empty($meta->processingduration) && isset($metas[$recordid]['processingduration'])) {
+                    $meta->processingduration = $metas[$recordid]['processingduration'];
+                }
+                // This sets the wait/queue time before the video starts being processed.
+                if (empty($meta->queueduration) &&
+                        !empty($metas[$recordid]['lastmodified']) &&
+                        !empty($metas[$recordid]['processingduration']) &&
+                        $recordings[$recordid]['endTime']) {
+                    // Queue duration = last modified - processing duration - end time (for meeting).
+                    $meta->queueduration = $metas[$recordid]['lastmodified'] -
+                        $metas[$recordid]['processingduration'] -
+                        $recordings[$recordid]['endTime'];
+                }
+
+                // Mark the record if no recording was detected, or should be considered recording-free.
+                if (!isset($recordings[$recordid])) {
+                    // Check and see if the record has a lastchecked already linked to it.
+                    // If it has surpassed the threshold, it is safe to consider the meeting
+                    // as having not been recorded.
+                    if (time() > $meeting->timecreated + TIME_BEFORE_FLAGGING_AS_NOT_RECORDED) {
+                        unset($meta->lastchecked);
+                        $meta->recorded = false;
+                    } else {
+                        // Set a lastchecked timestamp, to ensure subsequent requests within a
+                        // certain threshold (defaulting to 20 minutes) are not made and the
+                        // requesting is skipped.
+                        $meta->lastchecked = time();
+                    }
+
+                    $DB->update_record('bigbluebuttonbn_logs', ['id' => $meeting->id, 'meta' => json_encode($meta)]);
+                    continue;
+                }
+
+                $endtime = $recordings[$recordid]['endTime'];
+                $meta->endtime = $endtime;
+                $meta->recordingprocessingtime = $meta->recordinglastmodified - $meta->endtime;
+                unset($meta->lastchecked); // Clear this value if it exists as it is only relevant for processing the queue.
+                $DB->update_record('bigbluebuttonbn_logs', ['id' => $meeting->id, 'meta' => json_encode($meta)]);
+            }
+        }
+    }
+}

--- a/db/access.php
+++ b/db/access.php
@@ -126,4 +126,13 @@ $capabilities = array(
         ),
         'clonepermissionsfrom' => 'mod/bigbluebuttonbn:addinstance',
     ),
+    // Ability to see the recordings analytics report.
+    'mod/bigbluebuttonbn:recording_analytics' => array(
+        'captype' => 'read',
+        'contextlevel' => CONTEXT_SYSTEM,
+        'archetypes' => array(
+            'manager' => CAP_ALLOW
+        ),
+        'clonepermissionsfrom' => 'moodle/site:config'
+    )
 );

--- a/db/tasks.php
+++ b/db/tasks.php
@@ -15,20 +15,25 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Version for BigBlueButtonBN Moodle Activity Module.
+ * This file defines tasks performed by the plugin.
  *
- * @package   mod_bigbluebuttonbn
- * @copyright 2010 onwards, Blindside Networks Inc
- * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- * @author    Jesus Federico  (jesus [at] blindsidenetworks [dt] com)
- * @author    Fred Dixon  (ffdixon [at] blindsidenetworks [dt] com)
+ * @package    mod_bigbluebuttonbn
+ * @author     Kevin Pham <kevinpham@catalyst-au.net>
+ * @copyright  Catalyst IT, 2021
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die;
+defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2020050512;
-$plugin->requires = 2016120500;
-$plugin->cron = 0;
-$plugin->component = 'mod_bigbluebuttonbn';
-$plugin->maturity = MATURITY_RC;
-$plugin->release = '2.4-rc';
+// List of tasks.
+$tasks = array(
+    array(
+        'classname' => '\mod_bigbluebuttonbn\task\fetch_recording_metadata_task',
+        'blocking' => 0,
+        'minute' => '*',
+        'hour' => '*',
+        'day' => '*',
+        'dayofweek' => '*',
+        'month' => '*'
+    )
+);

--- a/lang/en/bigbluebuttonbn.php
+++ b/lang/en/bigbluebuttonbn.php
@@ -101,6 +101,7 @@ $string['completionvalidatestate'] = "Validate completion";
 $string['completionvalidatestatetriggered'] = "Validate completion has been triggered.";
 
 $string['sendnotification'] = "Send notification";
+$string['fetchmetaforrecordings'] = "Fetch metadata for recordings";
 
 $string['minute'] = 'minute';
 $string['minutes'] = 'minutes';
@@ -699,6 +700,30 @@ $string['view_analytics_number_of_students_speaking'] = '# of Students Speaking'
 $string['view_analytics_number_of_students_messaging'] = '# of Students Messaging';
 $string['view_analytics_number_of_students_using_emojis'] = '# of Students Using Emojis';
 $string['view_analytics_number_of_students_raising_hands'] = '# of Students Raising Hands';
+
+$string['view_analytics_heading_recordings'] = 'BBB Recording Analytics';
+$string['view_analytics_total_recordings'] = 'Total Recordings';
+$string['view_analytics_total_storage_used'] = 'Total Storage Used';
+$string['view_analytics_total_playback_duration'] = 'Total Playback Duration';
+$string['view_analytics_total_processing_time'] = 'Total Processing Time';
+$string['view_analytics_average_queue_time'] = 'Average Queue Time';
+$string['view_analytics_average_processing_time'] = 'Average Processing Time';
+$string['view_analytics_processing_speed'] = 'Processing Speed Estimate'; // Calculated by (filesize / duration) ~= bytes per second.
+
+$string['view_analytics_recorded'] = 'Recorded';
+$string['view_analytics_recorded_status_unknown'] = 'Unknown';
+$string['view_analytics_recordingprocessingtime'] = 'Rec. Processing Time';
+$string['view_analytics_createtime'] = 'Meeting Created At';
+$string['view_analytics_starttime'] = 'Meeting Started At';
+$string['view_analytics_endtime'] = 'Meeting Ended At';
+$string['view_analytics_playbackduration'] = 'Playback Duration';
+$string['view_analytics_duration'] = 'Meeting Duration';
+$string['view_analytics_processingtime'] = 'Processing Started At';
+$string['view_analytics_processingduration'] = 'Processing Duration';
+$string['view_analytics_lastchecked'] = 'Meta Last Checked';
+$string['view_analytics_filesize'] = 'Filesize';
+$string['view_analytics_queuestarttime'] = 'Queued At';
+$string['view_analytics_queueduration'] = 'Queue Duration';
 
 $string['strftimetime24seconds'] = '%H:%M:%S';
 $string['strftimetime12seconds'] = '%I:%M:%S %p';

--- a/settings.php
+++ b/settings.php
@@ -63,3 +63,8 @@ if ($hassiteconfig) {
     // Renders settings for experimental features.
     bigbluebuttonbn_settings_experimental($renderer);
 }
+
+// Adds the recordings analytics report to the /admin/search.php#linkreports page.
+$ADMIN->add('reports', new admin_externalpage('bigbluebuttonbnrecordingsanalyticsreport',
+    get_string('view_analytics_heading_recordings', 'bigbluebuttonbn'),
+    "$CFG->wwwroot/mod/bigbluebuttonbn/analytics-recordings.php"));


### PR DESCRIPTION
- Includes scheduled task to fetch and update logs with recording metadata (lastmodified, meeting endtime, queue duration)
- Includes report showing overall and past week metrics

See example below:
![image](https://user-images.githubusercontent.com/9924643/120155050-d2c24600-c233-11eb-8515-b252176a759c.png)
