### PR TITLE
Add meetingKeepEvents to the meeting creation call, to fix post meeting events callback

### DIFF
--- a/bbb_view.php
+++ b/bbb_view.php
@@ -379,12 +379,16 @@ function bigbluebuttonbn_bbb_view_create_meeting_data(&$bbbsession) {
     if ($bbbsession['lockonjoinconfigurable']) {
         $data['lockSettingsLockOnJoinConfigurable'] = 'true';
     }
-    // Check global mod settings first, otherwise check activity instance settings
+    // Check global mod settings first, otherwise check activity instance settings.
     if (
         \mod_bigbluebuttonbn\locallib\config::get('participant_guest_requires_moderator_approval')
         || $bbbsession['bigbluebuttonbn']->moderatorapproval
     ) {
         $data['guestPolicy'] = 'ASK_MODERATOR';
+    }
+    // Ensure meeting events are stored such that the BBB server can push meeting events back once it ends.
+    if ((boolean) \mod_bigbluebuttonbn\locallib\config::get('meetingevents_enabled')) {
+        $data['meetingKeepEvents'] = 'true'; // Option added as per PR #11681.
     }
     return $data;
 }


### PR DESCRIPTION
As per https://github.com/bigbluebutton/bigbluebutton/pull/11681 and https://github.com/bigbluebutton/bigbluebutton.github.io/pull/239/files it seems that this new option was added to let the client control whether or not the data should be stored. The data needs to be stored if meeting stats are required so it can be sent back from the BBB server