### PR TITLE
Proxy: use current schema instead of assuming HTTP

### DIFF
--- a/proxy_presentation.php
+++ b/proxy_presentation.php
@@ -112,7 +112,7 @@ $curl->setopt([
             // than doing many more str_replaces).
             $body = str_replace('src="/', 'src="', $body);
             $body = str_replace('href="/', 'href="', $body);
-            $body = str_replace('<head>', '<head><base href="http://'.$proxybase.'/">', $body);
+            $body = str_replace('<head>', '<head><base href="//'.$proxybase.'/">', $body);
             // This one was added as it seemed like it was being used to
             // reference the base URL of the web app. As this going through the
             // proxy, it would need to have this file as the prefix for the URL


### PR DESCRIPTION
HTTP had previously been used during local testing which was why it was added in the first place.