### PR TITLE
Fix db upgrade, lockonjoinconfigurable does not exist on log table

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -337,7 +337,7 @@ function xmldb_bigbluebuttonbn_upgrade($oldversion = 0) {
             ['userid', 'log']);
         // Add field recordid to bigbluebuttonbn_logs table.
         $fielddefinition = array('type' => XMLDB_TYPE_CHAR, 'precision' => '255', 'unsigned' => null,
-            'notnull' => null, 'sequence' => null, 'default' => null, 'previous' => 'lockonjoinconfigurable');
+            'notnull' => null, 'sequence' => null, 'default' => null, 'previous' => 'meetingid');
         xmldb_bigbluebuttonbn_add_change_field($dbman, 'bigbluebuttonbn_logs', 'recordid',
             $fielddefinition);
         upgrade_mod_savepoint(true, 2020050513, 'bigbluebuttonbn');


### PR DESCRIPTION
Updated to match order of install.xml

https://github.com/catalyst/moodle-mod_bigbluebuttonbn/blob/master-catalyst/db/install.xml#L63