### PR TITLE
Fix proxy handling, fix 2.3 urls checks, updated playback url handling.

### DIFF
--- a/bbb_view.php
+++ b/bbb_view.php
@@ -234,7 +234,16 @@ switch (strtolower($action)) {
 
         if ((bool)\mod_bigbluebuttonbn\locallib\config::get('recordings_proxy_playback')) {
             $parseurl = parse_url($href);
-            $path = $parseurl['path'];
+
+            // Handle path restructuring for use with the proxy/redirects.
+            if (basename($parseurl['path']) === 'playback.html') {
+                // Keep urls e.g. playback.html?meetingId=1234 as-is for legacy BBB.
+                $path = $parseurl['path'];
+            } else {
+                // Make sure path ends in '/' e.g. playback/presentation/2.3/1234-123 for 2.3 and above.
+                $path = rtrim($parseurl['path']) . '/';
+            }
+
             $query = $parseurl['query'] ?? '';
             $location = "./proxy_presentation.php{$path}?{$query}";
         } else {

--- a/proxy_presentation.php
+++ b/proxy_presentation.php
@@ -101,7 +101,7 @@ $curl->setopt([
         }
 
         // HACK: Version 2.3+ replaces to ensure it routes all assets and subsequent calls through the proxy appropriately.
-        if (strpos($relativepath, '2.0') === false) {
+        if (strpos($relativepath, '2.0') === false && strpos($relativepath, '/capture/') === false) {
             // Due to it referencing other resources non-relatively, which was
             // implied for a non-proxied playback, it would not go through the
             // proxy and instead attempt to use a resource at which doesn't


### PR DESCRIPTION
- Strict checks against 2.3 BBB for proxy.
- Add trailing slash to BBB 'play' urls to fix new format.
- Add backwards check and support for legacy BBB.