### PR TITLE
Remove '/' prefix in relative path

### DIFF
--- a/proxy_presentation.php
+++ b/proxy_presentation.php
@@ -133,4 +133,4 @@ $curl->setopt([
     },
 ]);
 
-$curl->get(\mod_bigbluebuttonbn\locallib\bigbluebutton::root() . $relativepath);
+$curl->get(\mod_bigbluebuttonbn\locallib\bigbluebutton::root() . ltrim($relativepath, '/'));


### PR DESCRIPTION
This is because it would be combined with the bbb server url, and sometimes would result internally calling:
`https://myserver//playback/etc`
Which resolves to 404 since the path is not valid.