### PR TITLE
Fix recordid checks as the key might not always exist

### DIFF
--- a/classes/analytics/analytics_for_recordings_table.php
+++ b/classes/analytics/analytics_for_recordings_table.php
@@ -79,7 +79,7 @@ class analytics_for_recordings_table extends \table_sql {
         $data = json_decode($row->meta);
         if (!empty($data->playbackduration)) {
             return "Ready"; // Recording details known and stored.
-        } else if ($data->recordid === null) {
+        } else if (!isset($data->recordid)) {
             return "Invalid"; // No record id on the entry, no way to check for recording.
         } else if ((isset($data->recorded) && $data->recorded == false) || // Not recorded.
                    (isset($data->record) && $data->record !== "true") // Record functionality not enabled.


### PR DESCRIPTION
This is because the key comes from $data which is a json_decoded object formed from the meta field of the log table