### PR TITLE
Sort the recordings table (time DESC)

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -2171,6 +2171,9 @@ function bigbluebutton_get_recordings_for_table_view($bbbsession, $enabledfeatur
 
     }
 
+    // Sort the recordings by time, reversed (so this displays the more recent recordings at the top)
+    krsort($recordings);
+
     if ($enabledfeatures['importrecordings']) {
         // Get recording links.
         $bigbluebuttonbnid = $bbbsession['bigbluebuttonbn']->id;


### PR DESCRIPTION
This was previously broken as analytic entries were just added at the end despite being an associative array