### PR TITLE
Fix meta prop handling to not throw warnings even if it is not set

### DIFF
--- a/bbb_view.php
+++ b/bbb_view.php
@@ -136,7 +136,9 @@ switch (strtolower($action)) {
             );
         $accesses = $DB->get_records_select('bigbluebuttonbn_logs', $select, $params, 'id ASC', 'id, meta', 1);
         $lastaccess = end($accesses);
-        $lastaccess = json_decode($lastaccess->meta);
+        if (!empty($lastaccess->meta)) {
+            $lastaccess = json_decode($lastaccess->meta);
+        }
         // If the user acceded from Timeline it should be redirected to the Dashboard.
         if (isset($lastaccess->origin) && $lastaccess->origin == BIGBLUEBUTTON_ORIGIN_TIMELINE) {
             redirect($CFG->wwwroot . '/my/');


### PR DESCRIPTION
- Checked and it handles it okay with it set, and without it set.

This was the snippet added before the new check to confirm how it's expected to work when coming from the TIMELINE page. 
`$lastaccess = (object)['meta' => json_encode(['origin'=>BIGBLUEBUTTON_ORIGIN_TIMELINE])];`

Also tested setting it to `null` and the default value set when loading from within the activity. Seems to all be okay with this new check.
