### PR TITLE
Bump default processing limit to 1000

### DIFF
--- a/classes/task/fetch_recording_metadata_task.php
+++ b/classes/task/fetch_recording_metadata_task.php
@@ -26,7 +26,7 @@ const TIME_BEFORE_FLAGGING_AS_NOT_RECORDED = 2 * WEEKSECS;
 // This is a limit documented in code @  bigbluebuttonbn_get_recordings_array_fetch_page function call.
 const BBB_API_GET_RECORDINGS_RECORDS_PER_REQUEST = 25;
 // Default processing limit for backlog of BBB sessions.
-const DEFAULT_PROCESSING_LIMIT = 100;
+const DEFAULT_PROCESSING_LIMIT = 1000;
 
 /**
  * A scheduled task to fetch the recordings' metadata and store it for further reporting


### PR DESCRIPTION
Too few records processed, and the queue could clog up if there are enough meetings that are created between checks that do not have recordings.

Bumping this to 1000 should be adequate for general usage.