### PR TITLE
Change shared_secret to be a masked config password admin setting

### DIFF
--- a/classes/settings/renderer.php
+++ b/classes/settings/renderer.php
@@ -122,6 +122,23 @@ class renderer {
     }
 
     /**
+     * Render a configpasswordunmask element in a group.
+     *
+     * @param string    $name
+     * @param object    $default
+     * @param string    $type
+     *
+     * @return Object
+     */
+    public function render_group_element_configpasswordunmask($name, $default = null, $type = PARAM_RAW) {
+        $item = new \admin_setting_configpasswordunmask('bigbluebuttonbn_' . $name,
+            get_string('config_' . $name, 'bigbluebuttonbn'),
+            get_string('config_' . $name . '_description', 'bigbluebuttonbn'),
+            $default);
+        return $item;
+    }
+
+    /**
      * Render a checkbox element in a group.
      *
      * @param string    $name

--- a/locallib.php
+++ b/locallib.php
@@ -2865,7 +2865,7 @@ function bigbluebuttonbn_settings_general(&$renderer) {
         );
         $renderer->render_group_element(
             'shared_secret',
-            $renderer->render_group_element_text('shared_secret', BIGBLUEBUTTONBN_DEFAULT_SHARED_SECRET)
+            $renderer->render_group_element_configpasswordunmask('shared_secret', BIGBLUEBUTTONBN_DEFAULT_SHARED_SECRET)
         );
     }
 }


### PR DESCRIPTION
Such that when the config setting is forced, MDL-63734 will prevent the secret from being observed in the admin settings page.