### PR TITLE
Fix recording analytics filtering, pagination and table data download

### DIFF
--- a/analytics-recordings.php
+++ b/analytics-recordings.php
@@ -59,28 +59,29 @@ if (!empty($bn)) {
 }
 require_capability('mod/bigbluebuttonbn:recordinganalytics', context_system::instance());
 
+
+// Setup filter form for the main table.
+$form = new \mod_bigbluebuttonbn\form\analytics_recording_filter_form();
+if (!$formdata = $form->get_data()) {
+    $formdata = new stdClass();
+    $formdata->filterstart = optional_param('filterstart', time() - 2 * WEEKSECS, PARAM_INT);
+    $formdata->filterall = optional_param('filterall', false, PARAM_BOOL);
+}
+
+$form->set_data($formdata);
+
 // Print the page header.
-$pageurl = new moodle_url('/mod/bigbluebuttonbn/analytics-recordings.php', ['bn' => $bn]);
+$pageurl = new moodle_url('/mod/bigbluebuttonbn/analytics-recordings.php', array_merge(convert_to_array($formdata), ['bn' => $bn]));
 $PAGE->set_url($pageurl);
 $PAGE->set_title($title);
 $PAGE->set_cacheable(false);
 $PAGE->set_heading($heading);
 
-// Setup filter form for the main table.
-$form = new \mod_bigbluebuttonbn\form\analytics_recording_filter_form();
-if ($formdata = $form->get_data()) {
-    $filterstart = $formdata->filterstart;
-    $filtershowall = $formdata->filterall;
-} else {
-    $filterstart = time() - 2 * WEEKSECS;
-    $filtershowall = false;
-}
-
 $table = new \mod_bigbluebuttonbn\analytics\analytics_for_recordings_table(
     'bigbluebuttonbn_recordings_metrics_table',
     $PAGE->url,
-    $filtershowall,
-    $filterstart
+    $formdata->filterall,
+    $formdata->filterstart
 );
 $table->is_downloading($download, 'bigbluebuttonbn-recordinganalytics-' . time());
 

--- a/classes/analytics/analytics_for_recordings_table.php
+++ b/classes/analytics/analytics_for_recordings_table.php
@@ -182,14 +182,9 @@ class analytics_for_recordings_table extends \table_sql {
             return;
         }
 
-        $counter = 0;
         foreach ($this->rawdata as $row) {
             $formattedrow = $this->format_row($row);
 
-            // Once the row is formatted, we can decide on whether it should be displayed.
-            if ($counter > $this->pagesize) {
-                break;
-            }
             // Check for time filter.
             if ($this->time < $this->timefilter) {
                 continue;
@@ -199,7 +194,6 @@ class analytics_for_recordings_table extends \table_sql {
             }
 
             $this->add_data_keyed($formattedrow, $this->get_row_class($row));
-            $counter++;
         }
     }
 }


### PR DESCRIPTION
The issue was caused by filter params not being passed through to the
pagination filters and csv download. Fixed by ensuring these values are
provided to set_url which will allow it to be passed along as needed,
and added additional handling to ensure the filter form stays filtered
on subsequent pagination changes.