### PR TITLE
Remove the duplicated BBB title inclusion which displayed twice

### DIFF
--- a/viewlib.php
+++ b/viewlib.php
@@ -115,8 +115,6 @@ function bigbluebuttonbn_view_render(&$bbbsession, $activity) {
     $output .= bigbluebuttonbn_view_warning_default_server($bbbsession);
     $output .= bigbluebuttonbn_view_warning_general($bbbsession);
 
-    // Renders the rest of the page.
-    $output .= $OUTPUT->heading($bbbsession['meetingname'], 3);
     // Renders the completed description.
     $desc = file_rewrite_pluginfile_urls($bbbsession['meetingdescription'], 'pluginfile.php',
         $bbbsession['context']->id, 'mod_bigbluebuttonbn', 'intro', null);


### PR DESCRIPTION
Removes the extra title rendered for all BBB view pages

Before:

![image](https://user-images.githubusercontent.com/9924643/140676779-561eeb91-65b7-41ed-9bd7-42cf4b8682c8.png)

After

![image](https://user-images.githubusercontent.com/9924643/140676724-fe2ba0a9-53b1-4a0a-baaf-417a729cdf43.png)


Unit Tests are okay after changes:
```
Moodle 3.9.10+ (Build: 20210917), 235e49e5250d0dc585df137f25c164a4f1ac87e4
Php: 7.3.28, pgsql: 10.17 (Debian 10.17-1.pgdg90+1), OS: Linux 5.4.0-88-generic x86_64
PHPUnit 7.5.20 by Sebastian Bergmann and contributors.

........................S...............S.......................  64 / 64 (100%)

Time: 15.96 seconds, Memory: 616.00 MB

OK, but incomplete, skipped, or risky tests!
Tests: 64, Assertions: 175, Skipped: 2.
```

