### PR TITLE
Add a warning section for when a recording is probably being processed

### DIFF
--- a/lang/en/bigbluebuttonbn.php
+++ b/lang/en/bigbluebuttonbn.php
@@ -666,6 +666,7 @@ $string['view_error_meeting_not_running'] = 'Something went wrong, the meeting i
 $string['view_error_current_state_not_found'] = 'Current state was not found. The recording may have been deleted or the BigBlueButton server is not compatible with the action performed.';
 $string['view_error_action_not_completed'] = 'Action could not be completed';
 $string['view_warning_default_server'] = 'This Moodle server is making use of the BigBlueButton testing server that comes pre-configured by default. It should be replaced for production.';
+$string['view_warning_recording_is_processing'] = 'A recording may be processing and will be shown below once complete. Please be patient, processing times may vary and can take up to a few hours.';
 
 $string['view_room'] = 'View room';
 $string['mod_form_block_clienttype'] = 'Web Client Technology';

--- a/viewlib.php
+++ b/viewlib.php
@@ -150,14 +150,44 @@ function bigbluebuttonbn_view_render(&$bbbsession, $activity) {
  * @return string
  */
 function bigbluebuttonbn_view_render_recording_section(&$bbbsession, $type, $enabledfeatures, &$jsvars) {
+    global $DB, $OUTPUT;
     if ($type == BIGBLUEBUTTONBN_TYPE_ROOM_ONLY) {
         return '';
     }
     $output = '';
     if ($type == BIGBLUEBUTTONBN_TYPE_ALL && $bbbsession['record']) {
+        // Recordings Title.
         $output .= html_writer::start_tag('div', array('id' => 'bigbluebuttonbn_view_recordings_header'));
         $output .= html_writer::tag('h4', get_string('view_section_title_recordings', 'bigbluebuttonbn'));
         $output .= html_writer::end_tag('div');
+
+        // Check and display recording is processing notification if recordings
+        // are or might be currently processing, checking the last meeting for
+        // performance reasons.
+        $sql = "SELECT id, timecreated, meta
+                  FROM {bigbluebuttonbn_logs}
+                 WHERE recordid IS NOT NULL
+                   AND log = :log
+                   AND bigbluebuttonbnid = :bigbluebuttonbnid
+                   AND ".$DB->sql_like('meta', ':recordable')."
+              ORDER BY timecreated DESC
+                 LIMIT 1";
+        $record = $DB->get_record_sql($sql, [
+            'log' => BIGBLUEBUTTONBN_LOG_EVENT_CREATE,
+            'bigbluebuttonbnid' => $bbbsession['bigbluebuttonbn']->id,
+            'recordable' => '%"record":"true"%', // Recording is enabled.
+        ], IGNORE_MISSING);
+        // Check the metadata to check whether the last meeting created is
+        // (probably) being processed and display the warning accordingly.
+        if (!empty($record->meta)) {
+            $meta = json_decode($record->meta);
+            if (!empty($meta) && !isset($meta->recorded) && !isset($meta->recordingprocessingtime)) {
+                // Processing pending notification.
+                $output .= $OUTPUT->notification(
+                    get_string('view_warning_recording_is_processing', 'bigbluebuttonbn'),
+                    'warning');
+            }
+        }
     }
     if ($type == BIGBLUEBUTTONBN_TYPE_RECORDING_ONLY || $bbbsession['record']) {
         $output .= html_writer::start_tag('div', array('id' => 'bigbluebuttonbn_view_recordings_content'));


### PR DESCRIPTION
- This will only display for the last meeting created from that instance (for performance reasons, which should also cover typical usage)
- This should only display if the meeting is 'recordable' and not processed as recorded.
- This displays under the 'Recordings' heading of the recordings table

After:
![image](https://user-images.githubusercontent.com/9924643/140685585-60cd8d42-d25f-4b07-b211-864d68709c11.png)
