### PR TITLE
fix: processing of recording metadata from analytics

### DIFF
--- a/classes/analytics/analytics_for_recordings_table.php
+++ b/classes/analytics/analytics_for_recordings_table.php
@@ -102,7 +102,7 @@ class analytics_for_recordings_table extends \table_sql {
         }
 
         // Confirmed as having recording markers, and should be currently processing.
-        if (isset($data->lastchecked) && !empty($data->hasrecordingmarkers)) {
+        if (isset($data->lastchecked) && !empty($data->recorded)) {
             return get_string('view_analytics_status_processing', 'mod_bigbluebuttonbn');
         }
 

--- a/classes/task/fetch_recording_metadata_task.php
+++ b/classes/task/fetch_recording_metadata_task.php
@@ -193,17 +193,34 @@ class fetch_recording_metadata_task extends \core\task\scheduled_task {
 
                 // Mark the record if no recording was detected, or should be considered recording-free.
                 if (!isset($recordings[$recordid])) {
+                    // Set a lastchecked timestamp, to ensure subsequent requests within a
+                    // certain threshold (defaulting to 20 minutes) are not made and the
+                    // requesting is skipped.
+                    $meta->lastchecked = time();
+
                     // Check and see if the record has a lastchecked already linked to it.
                     // If it has surpassed the threshold, it is safe to consider the meeting
                     // as having not been recorded.
-                    if (time() > $meeting->timecreated + TIME_BEFORE_FLAGGING_AS_NOT_RECORDED) {
+                    if (time() > ($meeting->timecreated + TIME_BEFORE_FLAGGING_AS_NOT_RECORDED)) {
                         unset($meta->lastchecked);
                         $meta->recorded = false;
-                    } else {
-                        // Set a lastchecked timestamp, to ensure subsequent requests within a
-                        // certain threshold (defaulting to 20 minutes) are not made and the
-                        // requesting is skipped.
-                        $meta->lastchecked = time();
+                    }
+
+                    // As long as the recording isn't considered expired - due to too long of a wait time.
+                    // Check and see if the recording analytics returned anything meaningful (e.g. hasrecordingmarkers).
+                    if (!isset($meta->recorded) || $meta->recorded !== true) {
+                        $summary = $DB->get_record('bigbluebuttonbn_logs', [
+                            'meetingid' => $meeting->meetingid,
+                            'recordid' => $recordid,
+                            'userid' => null,
+                            'log' => BIGBLUEBUTTON_LOG_EVENT_SUMMARY
+                        ]);
+                        if (!empty($summary)) {
+                            $summarymeta = json_decode($summary->meta);
+                            if (property_exists($summarymeta, 'hasrecordingmarkers')) {
+                                $meta->recorded = (bool) $summarymeta->hasrecordingmarkers;
+                            }
+                        }
                     }
 
                     $DB->update_record('bigbluebuttonbn_logs', ['id' => $meeting->id, 'meta' => json_encode($meta)]);


### PR DESCRIPTION
Though the data was available, it was not properly considered when updating the status of the recording. Also since the recording state was never set in the CREATE log record, and only in the SUMMARY, this was never properly reflected in the table.

Instead of doing a join just for reporting purposes, now it will update the recorded flag via the task, and should sync the recordings report with the proper status for sessions that are recorded, but not yet available as 'Processing'.
